### PR TITLE
fix warning with clang on HiFi4

### DIFF
--- a/silk/interface/SKP_Silk_SDK_API.h
+++ b/silk/interface/SKP_Silk_SDK_API.h
@@ -143,7 +143,7 @@ void SKP_Silk_SDK_get_TOC(
 /* Get the version number */
 /**************************/
 /* Return a pointer to string specifying the version */ 
-const char *SKP_Silk_SDK_get_version();
+const char *SKP_Silk_SDK_get_version(void);
 
 #ifdef __cplusplus
 }

--- a/silk/src/SKP_Silk_AsmPreproc.h
+++ b/silk/src/SKP_Silk_AsmPreproc.h
@@ -105,6 +105,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #elif defined (__ARM_ARCH_7A__)
 #define EMBEDDED_ARM 6
 #define EMBEDDED_ARMv6
+#else
+#define EMBEDDED_ARM 0
 #endif
 #endif
 

--- a/silk/src/SKP_Silk_Inlines.h
+++ b/silk/src/SKP_Silk_Inlines.h
@@ -252,7 +252,7 @@ SKP_INLINE SKP_int32 SKP_Silk_SIN_APPROX_Q24(        /* O    returns approximate
         }
         if( x < 1100 ) {
             /* Special case: high accuracy */
-            return SKP_SMLAWB( -1 << 24, SKP_MUL( x, x ), 5053 );
+            return SKP_SMLAWB( -(1 << 24), SKP_MUL( x, x ), 5053 );
         }
         x = SKP_SMULWB( SKP_LSHIFT( x, 8 ), x );        /* contains x^2 in Q20 */
         y_Q30 = SKP_SMLAWB( -SKP_SIN_APPROX_CONST2, x, -SKP_SIN_APPROX_CONST3 );

--- a/silk/src/SKP_Silk_NSQ.c
+++ b/silk/src/SKP_Silk_NSQ.c
@@ -331,7 +331,7 @@ SKP_INLINE void SKP_Silk_noise_shape_quantizer(
         /* Flip sign depending on dither */
         r_Q10 = ( r_Q10 ^ dither ) - dither;
         r_Q10 = SKP_SUB32( r_Q10, offset_Q10 );
-        r_Q10 = SKP_LIMIT_32( r_Q10, -64 << 10, 64 << 10 );
+        r_Q10 = SKP_LIMIT_32( r_Q10, -(64 << 10), 64 << 10 );
 
         /* Quantize */
         q_Q0 = 0;

--- a/silk/src/SKP_Silk_NSQ_del_dec.c
+++ b/silk/src/SKP_Silk_NSQ_del_dec.c
@@ -475,7 +475,7 @@ SKP_INLINE void SKP_Silk_noise_shape_quantizer_del_dec(
             /* Flip sign depending on dither */
             r_Q10 = ( r_Q10 ^ dither ) - dither;
             r_Q10 = SKP_SUB32( r_Q10, offset_Q10 );
-            r_Q10 = SKP_LIMIT_32( r_Q10, -64 << 10, 64 << 10 );
+            r_Q10 = SKP_LIMIT_32( r_Q10, -(64 << 10), 64 << 10 );
 
             /* Find two quantization level candidates and measure their rate-distortion */
             if( r_Q10 < -1536 ) {

--- a/silk/src/SKP_Silk_SigProc_FIX.h
+++ b/silk/src/SKP_Silk_SigProc_FIX.h
@@ -65,6 +65,7 @@ extern "C"
 #		include "SKP_Silk_macros.h"
 #	endif
 #else
+#	define EMBEDDED_ARM 0
 #	include "SKP_Silk_macros.h"
 #endif
 

--- a/silk/src/SKP_Silk_ana_filt_bank_1.c
+++ b/silk/src/SKP_Silk_ana_filt_bank_1.c
@@ -39,7 +39,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 /* Coefficients for 2-band filter bank based on first-order allpass filters */
 // old
 static SKP_int16 A_fb1_20[ 1 ] = {  5394 << 1 };
-static SKP_int16 A_fb1_21[ 1 ] = { 20623 << 1 };        /* wrap-around to negative number is intentional */
+static SKP_int16 A_fb1_21[ 1 ] = {  (SKP_int16) (20623 << 1) };        /* wrap-around to negative number is intentional */
 
 /* Split signal into two decimated bands using first-order allpass filters */
 void SKP_Silk_ana_filt_bank_1(


### PR DESCRIPTION
silk/src/SKP_Silk_ana_filt_bank_1.c:42:42: warning: implicit conversion from 'int' to 'short' changes value from 41246 to -24290 [-Wconstant-conversion] silk/src/SKP_Silk_NSQ.c:334:42: warning: shifting a negative signed value is undefined [-Wshift-negative-value] silk/src/SKP_Silk_SigProc_FIX.h:496:5: warning: 'EMBEDDED_ARM' is not defined, evaluates to 0 [-Wundef]
