### PR TITLE
add: 22050 Hz

### DIFF
--- a/silk/src/SKP_Silk_enc_API.c
+++ b/silk/src/SKP_Silk_enc_API.c
@@ -124,7 +124,8 @@ SKP_int SKP_Silk_SDK_Encode(
     if( ( ( encControl->API_sampleRate        !=  8000 ) &&
           ( encControl->API_sampleRate        != 12000 ) &&
           ( encControl->API_sampleRate        != 16000 ) &&
-          ( encControl->API_sampleRate        != 24000 ) && 
+          ( encControl->API_sampleRate        != 22050 ) &&
+          ( encControl->API_sampleRate        != 24000 ) &&
           ( encControl->API_sampleRate        != 32000 ) &&
           ( encControl->API_sampleRate        != 44100 ) &&
           ( encControl->API_sampleRate        != 48000 ) ) ||


### PR DESCRIPTION
我尝试对 `22050 Hz` 的 WAV 文件 进行 encode 时发现不支持
翻看源码后发现不支持，但有 `44100 Hz` 的支持，所以尝试修改源码添加 `22050 Hz`，编译运行测试之后发现可以生成可用的 silk
所以我想问一下，是不是遗漏了对 `22050 Hz` 的支持

由于这个项目没开 issues 功能，所以直接开了 pr 来询问
如有冒犯，请多见谅

[22050 Hz 的 WAV 文件](https://github.com/kn007/silk-v3-decoder/files/10973515/22050.zip)