### PR TITLE
qqnt 末尾比官方少一个字节，不去掉语音无法在pc的qqnt上播放

### DIFF
--- a/silk/test/Encoder.c
+++ b/silk/test/Encoder.c
@@ -350,6 +350,13 @@ int main( int argc, char* argv[] )
     /* Write payload size */
     if( !tencent ) {
         fwrite( &nBytes, sizeof( SKP_int16 ), 1, bitOutFile );
+    } else {
+        // qqfile should remove 1 bytes
+        fseek(bitOutFile, -1L, SEEK_END);
+        long pos = ftell(bitOutFile);
+        if(pos >= 1) {
+            ftruncate(fileno(bitOutFile), pos);
+        }
     }
 
     /* Free Encoder */


### PR DESCRIPTION
另外一个 wasm 的silk仓库生成的文件可以播放，对比了多个silk文件，发现均是qq的比官方的末尾少一个字节（文件头则是多一个字节），经过测试把官方版最后一个字节去掉后就可以在所有平台播放了