### PR TITLE
nBytes 大于 sizeof(payload) 导致读取文件时 payload 数组溢出

### DIFF
--- a/silk/test/Decoder.c
+++ b/silk/test/Decoder.c
@@ -266,6 +266,11 @@ int main( int argc, char* argv[] )
             break;
         }
 
+        if( nBytes > MAX_BYTES_PER_FRAME * MAX_INPUT_FRAMES ) {
+            fprintf( stderr, "\rPacket is too large:             %d", nBytes );
+            return -1;
+        }
+
         /* Read payload */
         counter = fread( payloadEnd, sizeof( SKP_uint8 ), nBytes, bitInFile );
         if( ( SKP_int16 )counter < nBytes ) {
@@ -458,14 +463,6 @@ int main( int argc, char* argv[] )
         totBytes = 0;
         for( i = 0; i < MAX_LBRR_DELAY; i++ ) {
             totBytes += nBytesPerPacket[ i + 1 ];
-        }
-
-        /* Check if the received totBytes is valid */
-        if (totBytes < 0 || totBytes > sizeof(payload))
-        {
-            
-            fprintf( stderr, "\rPackets decoded:              %d", totPackets );
-            return -1;
         }
         
         SKP_memmove( payload, &payload[ nBytesPerPacket[ 0 ] ], totBytes * sizeof( SKP_uint8 ) );


### PR DESCRIPTION
我在做音频转换时，出现部分不合法的silk音频文件，处理时读取到后一个 packet 的大小（nBytes）远超过 silk 的最大限制：
`counter = fread( &nBytes, sizeof( SKP_int16 ), 1, bitInFile );`
因此导致读取的数据长度超过了 `payload` 的长度定义：
`SKP_uint8 payload[    MAX_BYTES_PER_FRAME * MAX_INPUT_FRAMES * ( MAX_LBRR_DELAY + 1 ) ];`
`counter = fread( payloadEnd, sizeof( SKP_uint8 ), nBytes, bitInFile );`
最终导致溢出：
`*** stack smashing detected ***: terminated`
因此我尝试修复这个问题，将已有对接收数据的合法性检测的代码提前到接收数据阶段：
`if (totBytes < 0 || totBytes > sizeof(payload)) { ... }`
after:
`if( nBytes > MAX_BYTES_PER_FRAME * MAX_INPUT_FRAMES ) { ... }`

我的主要方向不是 c/c++， 所以如有建议请和我反馈。
期待回复。